### PR TITLE
LICENSE file + license section in README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2001-2017 by Johan Kotlinski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Documentation: https://github.com/jkotlinski/lsdpatch/wiki/Documentation
 Tutorial by Little-Scale: http://little-scale.blogspot.com/2008/11/how-to-prepare-samples-and-create-lsdj.html
 
 Video tutorial by 2xAA: http://www.youtube.com/watch?v=FGeVrW5Jxww
+
+## License
+
+Copyright (C) 2001-2017 by Johan Kotlinski
+
+This project is licensed under the MIT License, see the [LICENSE](LICENSE) file for more details.


### PR DESCRIPTION
I added a LICENSE file containing the MIT License and a section in the README.md linking to it.

This would avoid confusion if someone open one of the two source files that doesn't contain the license header ([FileDrop.java][filedrop] and [StretchIcon.java][stretchicon]) like I did. It also let Github parse the license of the project and use it in several ways.

I'm not sure why these [two][filedrop] [files][stretchicon] are headerless so i didn't touched them. They both contain contributed code but at the same time it seems you're the only one who touched them. They're both fairly recent so it may be an oversight.

Regarding the copyright notice I'm not sure about the initial year you started the project. I picked the oldest one i could find, 2001. I don't think adding the last year the project was modified next to it holds any legal value. It could help people knows that it's still active however there is still the most recent commit at the top of the project page. Feel free to adjust.

I'm not used to the Issues/Pull Request workflow so i don't know if you can link that to the issue #29 and if it's relevant at all to do so.

This PR is not much but I hope it could be useful.

[filedrop]: https://github.com/jkotlinski/lsdpatch/blob/8f21104886bd97f4baa3ccb50f20bad1847f2ef5/FileDrop.java
[stretchicon]: https://github.com/jkotlinski/lsdpatch/blob/d65122e70834325de7bd214d7efe1cbf4057459e/StretchIcon.java