### PR TITLE
add ROM file selection to upgrade dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - ROM Upgrade Tool: "Select ROM file..." button allows upgrading to arbitrary ROM files instead of only downloading latest stable or experimental from littlesounddj.com.
 
 ## [1.13.3] - 2024-09-20
 ### Fixed


### PR DESCRIPTION
## use case
allows upgrading to arbitrary lsdj version instead of latest experimental or stable (e.g., 4.7.3 to 5.0.3) while preserving custom kits, fonts, and palettes.

## testing
successfully tested upgrading from patched lsdj 7.0.2 to 9.4.0 with custom sample kits, verified that custom sample kits persisted

> **note:** palette count mismatches between ROM versions can cause import to fail. in my actual use case (4.7.3 to 5.0.3), i temporarily commented out the palette import check to complete the upgrade. future enhancement could make palette import optional when count mismatches are detected.

## changes
- adds "Select ROM file..." button to ROM upgrade dialog
- validates file size matches expected ROM size
- reuses existing import logic for kits, fonts, and palettes